### PR TITLE
feat: keep core eslint packages in sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,8 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+  groups:
+    eslint-core:
+      patterns:
+        - "eslint"
+        - "@eslint/js"


### PR DESCRIPTION
This PR configures Dependabot make a single PR when updating

- "eslint"
- "@eslint/js"


This keeps these packages in sync.