### PR TITLE
fix: explicitly set token

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -31,5 +31,6 @@ jobs:
       - name: "🧹 Run Eslint"
         uses: reviewdog/action-eslint@v1
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-check
           fail_level: 'error'


### PR DESCRIPTION
## Issue

Running `eslint` locally displays errors:

```shell
npm run lint:js

> lint:js
> eslint


/home/user47/code/examples/linting/eslint-demo/src/scroll-to-top.js
   4:1  error  Expected indentation of 2 spaces but found 4   @stylistic/js/indent
...
```

This *should* trigger an error in the workflow but it is not.

## Solution

This PR attempts to cause the lint workflow to fail, so we can update it pass.
