### PR TITLE
refactor: dependabot checks monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
   open-pull-requests-limit: 10
 
 - package-ecosystem: npm

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
   open-pull-requests-limit: 10
   groups:
     eslint-core:


### PR DESCRIPTION
## Issue

Weekly checks are a little overkill for a demo app.

## Solution
This PR changes Dependabot schedule from 'weekly' to 'monthly'. This should reduce the overall dependabot PRs while still keeping the repository responable fresh.

Note: This should NOT affect security updates.